### PR TITLE
Add reproducible builds configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,3 +85,26 @@ license {
     mapping("java", "SLASHSTAR_STYLE")
     exclude("org/eclipse/tahu/protobuf/**")
 }
+
+// configure reproducible builds
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+
+    // normalize file permissions for reproducibility
+    // files: 0644 (rw-r--r--), directories: 0755 (rwxr-xr-x)
+    filePermissions {
+        unix("0644")
+    }
+    dirPermissions {
+        unix("0755")
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    // ensure consistent compilation across different JDK versions
+    options.compilerArgs.addAll(listOf(
+        "-parameters" // include parameter names for reflection (improves consistency)
+    ))
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,12 @@
 version=1.0.2-beta
+
+# reproducible builds configuration
+org.gradle.caching=true
+systemProp.file.encoding=UTF-8
+
+# JVM settings for consistent builds
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US
+
+# ensure consistent behavior across environments
+org.gradle.parallel=true
+org.gradle.daemon=true


### PR DESCRIPTION
## Summary
This PR adds reproducible builds configuration to ensure byte-identical artifacts across different build environments.

## Changes
- **build.gradle.kts**: Configure archive tasks for reproducible builds (timestamps, file order, permissions)
- **gradle.properties**: Add build cache and locale normalization
- **REPRODUCIBLE_BUILDS.md**: Comprehensive documentation on reproducible builds
- **verify-reproducible-build.sh**: Local verification script
- **.github/workflows/reproducible-build-test.yml**: CI workflow to test reproducibility across Ubuntu/macOS and different JDK versions
- **.github/workflows/README.md**: Workflow documentation

## What's Configured
- ✅ Normalized file timestamps (1980-02-01 00:00:00)
- ✅ Reproducible file ordering
- ✅ Normalized file permissions (0644 for files, 0755 for directories)
- ✅ UTF-8 encoding enforced
- ✅ Build cache enabled
- ✅ Locale normalization

## Testing
The GitHub Actions workflow tests reproducibility across:
- Different operating systems (Ubuntu vs macOS)
- Different JDK patch versions (11.0.21 vs 11.0.25)
- Same environment (two consecutive builds)

Run locally: `./verify-reproducible-build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)